### PR TITLE
Use `project: true` for @typescript-eslint/parser

### DIFF
--- a/scaffolding/.eslintrc.js
+++ b/scaffolding/.eslintrc.js
@@ -3,6 +3,6 @@ module.exports = {
     extends: require.resolve('@diplodoc/lint/eslint-config'),
     parserOptions: {
         tsconfigRootDir: __dirname,
-        project: ['./tsconfig.json'],
+        project: true,
     },
 };


### PR DESCRIPTION
**Motivation**: For repositories containing auxiliary packages (i.e. playground, storybook, tests, etc.) it often makes sense to have separate TSConfig files, defining different settings for path resolution, targets, etc. Thus it seems better to use `project: true` to leverage automatic TSConfig detection.

See https://typescript-eslint.io/packages/parser#project for docs on this option (although the docs linked are for a newer major release of ts-eslint/parser, this still applies to the ones we use now).